### PR TITLE
Raise on missing data key instead of silently passing plaintext through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `encrypt` and `decrypt` now raise `InvalidSecretError` when the manifest has no `data` key, instead of silently passing the content through. Previously such a manifest was printed back **unencrypted** in Ruby-inspect format — easy to redirect into an `.enc.yaml` file and commit plaintext secrets without noticing.
+
 ## [2.2.2] - 2026-03-31
 
 ### Changed

--- a/lib/kubekrypt/decryptor.rb
+++ b/lib/kubekrypt/decryptor.rb
@@ -20,7 +20,9 @@ module KubeKrypt
     end
 
     def self.call(content:, base64:)
-      return content unless content["data"]
+      unless content["data"]
+        raise InvalidSecretError, "no data key found — nothing to decrypt"
+      end
 
       key_name = content.fetch(METADATA_KEY).fetch(KMS_KEY.to_s)
       decryptor = new(key_name)

--- a/lib/kubekrypt/encryptor.rb
+++ b/lib/kubekrypt/encryptor.rb
@@ -14,7 +14,10 @@ module KubeKrypt
     end
 
     def self.call(content:, key_name:)
-      return content unless content["data"]
+      unless content["data"]
+        raise InvalidSecretError,
+          "no data key found — refusing to write the manifest through unencrypted"
+      end
 
       encryptor = new(key_name)
 

--- a/spec/kubekrypt/decryptor_spec.rb
+++ b/spec/kubekrypt/decryptor_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe KubeKrypt::Decryptor do
     context "when content has no data key" do
       let(:content) { {"apiVersion" => "v1"} }
 
-      it "returns content unchanged" do
-        expect(described_class.call(content: content, base64: false)).to eq(content)
+      it "raises InvalidSecretError" do
+        expect {
+          described_class.call(content: content, base64: false)
+        }.to raise_error(KubeKrypt::InvalidSecretError, /no data key/)
       end
     end
 

--- a/spec/kubekrypt/encryptor_spec.rb
+++ b/spec/kubekrypt/encryptor_spec.rb
@@ -32,8 +32,10 @@ RSpec.describe KubeKrypt::Encryptor do
     context "when content has no data key" do
       let(:content) { {"apiVersion" => "v1"} }
 
-      it "returns content unchanged" do
-        expect(described_class.call(content: content, key_name: key_name)).to eq(content)
+      it "raises InvalidSecretError instead of passing the manifest through unencrypted" do
+        expect {
+          described_class.call(content: content, key_name: key_name)
+        }.to raise_error(KubeKrypt::InvalidSecretError, /no data key/)
       end
     end
 


### PR DESCRIPTION
## Summary

Fixes a silent plaintext passthrough: `kubekrypt encrypt` on a manifest with no `data` key returned the parsed content **unencrypted**, printed in Ruby-inspect format. Redirected to an `.enc.yaml` file, this commits plaintext secrets to git with no error and no warning — which is exactly how we found it (a real `secrets.enc.yaml` in the k8s repo turned out to be plaintext).

Both `Encryptor.call` and `Decryptor.call` now raise `InvalidSecretError` when `data` is absent. The CLI already rescues this error class and exits 1 with a clean message.

## Test plan

- [x] New specs: encrypt raises on missing `data` (instead of passing the manifest through); decrypt raises on missing `data`.
- [x] `bundle exec rspec` — 28 examples, 0 failures.